### PR TITLE
Format code

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,5 +1,5 @@
 tabWidth: 4
-printWidth: 100
+printWidth: 120
 trailingComma: 'all'
 singleQuote: true
 bracketSpacing: false

--- a/CRM/SumfieldsAddonActivity/Config.php
+++ b/CRM/SumfieldsAddonActivity/Config.php
@@ -26,7 +26,6 @@ class CRM_SumfieldsAddonActivity_Config extends CRM_RcBase_Config
      * @param array $settings the data to save
      *
      * @return bool the status of the update process.
-     *
      * @throws CRM_Core_Exception.
      */
     public function updateSetting(string $key, array $settings): bool
@@ -35,6 +34,7 @@ class CRM_SumfieldsAddonActivity_Config extends CRM_RcBase_Config
         parent::load();
         $configuration = parent::get();
         $configuration[$key] = $settings;
+
         return parent::update($configuration);
     }
 
@@ -44,7 +44,6 @@ class CRM_SumfieldsAddonActivity_Config extends CRM_RcBase_Config
      * @param string $key
      *
      * @return array the settings for the key
-     *
      * @throws CRM_Core_Exception.
      */
     public function getSetting(string $key): array
@@ -52,6 +51,7 @@ class CRM_SumfieldsAddonActivity_Config extends CRM_RcBase_Config
         // load latest config
         parent::load();
         $configuration = parent::get();
+
         return isset($configuration[$key]) ? $configuration[$key] : [];
     }
 }

--- a/CRM/SumfieldsAddonActivity/Service.php
+++ b/CRM/SumfieldsAddonActivity/Service.php
@@ -5,6 +5,7 @@ use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
 class CRM_SumfieldsAddonActivity_Service
 {
     public const MULTIPLE_OPTIONS = ['multiple' => true, 'class' => 'crm-select2 huge'];
+
     public const SINGLE_OPTIONS = ['multiple' => false, 'class' => 'crm-select2 huge'];
 
     /**
@@ -173,7 +174,8 @@ class CRM_SumfieldsAddonActivity_Service
                 'weight' => '15',
                 'text_length' => '32',
                 'trigger_table' => 'civicrm_activity_contact',
-                'trigger_sql' => self::rewriteSql('(
+                'trigger_sql' => self::rewriteSql(
+                    '(
                     SELECT COALESCE(COUNT(1), 0)
                     FROM civicrm_activity_contact ac
                     LEFT JOIN civicrm_activity a ON a.id = ac.activity_id
@@ -182,7 +184,8 @@ class CRM_SumfieldsAddonActivity_Service
                     AND a.activity_type_id IN (%activity_sumfields_activity_type_ids)
                     AND a.status_id IN (%activity_sumfields_activity_status_ids)
                     AND a.activity_date_time >= DATE_SUB(CURDATE(), INTERVAL '.$day.' DAY)
-                )'),
+                )'
+                ),
             ];
         }
         // Add new optgroup that will contain the setting parameters for the activities
@@ -206,7 +209,8 @@ class CRM_SumfieldsAddonActivity_Service
             'weight' => '15',
             'text_length' => '32',
             'trigger_table' => 'civicrm_activity_contact',
-            'trigger_sql' => self::rewriteSql('(
+            'trigger_sql' => self::rewriteSql(
+                '(
                 SELECT MAX(a.activity_date_time)
                 FROM civicrm_activity_contact ac
                 LEFT JOIN civicrm_activity a ON a.id = ac.activity_id
@@ -214,7 +218,8 @@ class CRM_SumfieldsAddonActivity_Service
                 AND ac.record_type_id = %activity_sumfields_date_record_type_id
                 AND a.activity_type_id IN (%activity_sumfields_date_activity_type_ids)
                 AND a.status_id IN (%activity_sumfields_date_activity_status_ids)
-            )'),
+            )'
+            ),
         ];
         // Add new optgroup that will contain the setting parameters for the activities
         $custom['optgroups']['activity_sumfields_date_of_activity'] = [

--- a/CRM/SumfieldsAddonActivity/Upgrader.php
+++ b/CRM/SumfieldsAddonActivity/Upgrader.php
@@ -37,7 +37,6 @@ class CRM_SumfieldsAddonActivity_Upgrader extends CRM_SumfieldsAddonActivity_Upg
      * Database upgrade for the activity date fieldsets.
      *
      * @return bool
-     *
      * @throws CRM_Core_Exception
      */
     public function upgrade_5100()
@@ -54,6 +53,7 @@ class CRM_SumfieldsAddonActivity_Upgrader extends CRM_SumfieldsAddonActivity_Upg
         foreach ($needsToBeAdded as $newConfig) {
             $current[$newConfig] = $default[$newConfig];
         }
+
         return $config->update($current);
     }
 }

--- a/CRM/SumfieldsAddonActivity/Upgrader/Base.php
+++ b/CRM/SumfieldsAddonActivity/Upgrader/Base.php
@@ -53,15 +53,14 @@ class CRM_SumfieldsAddonActivity_Upgrader_Base
                 E::path()
             );
         }
+
         return self::$instance;
     }
 
     /**
      * Adapter that lets you add normal (non-static) member functions to the queue.
-     *
      * Note: Each upgrader instance should only be associated with one
      * task-context; otherwise, this will be non-reentrant.
-     *
      * ```
      * CRM_SumfieldsAddonActivity_Upgrader_Base::_queueAdapter($ctx, 'methodName', 'arg1', 'arg2');
      * ```
@@ -73,6 +72,7 @@ class CRM_SumfieldsAddonActivity_Upgrader_Base
         $instance->ctx = array_shift($args);
         $instance->queue = $instance->ctx->queue;
         $method = array_shift($args);
+
         return call_user_func_array([$instance, $method], $args);
     }
 
@@ -101,6 +101,7 @@ class CRM_SumfieldsAddonActivity_Upgrader_Base
     public function executeCustomDataFile($relativePath)
     {
         $xml_file = $this->extensionDir.'/'.$relativePath;
+
         return $this->executeCustomDataFileByAbsPath($xml_file);
     }
 
@@ -116,6 +117,7 @@ class CRM_SumfieldsAddonActivity_Upgrader_Base
     {
         $import = new CRM_Utils_Migrate_Import();
         $import->run($xml_file);
+
         return true;
     }
 
@@ -133,6 +135,7 @@ class CRM_SumfieldsAddonActivity_Upgrader_Base
             CIVICRM_DSN,
             $this->extensionDir.DIRECTORY_SEPARATOR.$relativePath
         );
+
         return true;
     }
 
@@ -160,12 +163,12 @@ class CRM_SumfieldsAddonActivity_Upgrader_Base
             null,
             true
         );
+
         return true;
     }
 
     /**
      * Run one SQL query.
-     *
      * This is just a wrapper for CRM_Core_DAO::executeSql, but it
      * provides syntactic sugar for queueing several tasks that
      * run different queries
@@ -176,15 +179,14 @@ class CRM_SumfieldsAddonActivity_Upgrader_Base
     {
         // FIXME verify that we raise an exception on error
         CRM_Core_DAO::executeQuery($query, $params);
+
         return true;
     }
 
     /**
      * Syntactic sugar for enqueuing a task which calls a function in this class.
-     *
      * The task is weighted so that it is processed
      * as part of the currently-pending revision.
-     *
      * After passing the $funcName, you can also pass parameters that will go to
      * the function. Note that all params must be serializable.
      */
@@ -197,6 +199,7 @@ class CRM_SumfieldsAddonActivity_Upgrader_Base
             $args,
             $title
         );
+
         return $this->queue->createItem($task, ['weight' => -1]);
     }
 
@@ -288,6 +291,7 @@ class CRM_SumfieldsAddonActivity_Upgrader_Base
         if (!$revision) {
             $revision = $this->getCurrentRevisionDeprecated();
         }
+
         return $revision;
     }
 
@@ -297,6 +301,7 @@ class CRM_SumfieldsAddonActivity_Upgrader_Base
         if ($revision = \Civi::settings()->get($key)) {
             $this->revisionStorageIsDeprecated = true;
         }
+
         return $revision;
     }
 
@@ -305,6 +310,7 @@ class CRM_SumfieldsAddonActivity_Upgrader_Base
         CRM_Core_BAO_Extension::setSchemaVersion($this->extensionName, $revision);
         // clean up legacy schema version store (CRM-19252)
         $this->deleteDeprecatedRevision();
+
         return true;
     }
 

--- a/info.xml
+++ b/info.xml
@@ -22,8 +22,8 @@
         <url desc="Support">https://github.com/reflexive-communications/sumfields-addon-activity/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2022-11-06</releaseDate>
-    <version>1.1.4</version>
+    <releaseDate>2023-03-08</releaseDate>
+    <version>1.1.5</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/sumfields_addon_activity.civix.php
+++ b/sumfields_addon_activity.civix.php
@@ -9,12 +9,13 @@
 class CRM_SumfieldsAddonActivity_ExtensionUtil
 {
     public const SHORT_NAME = 'sumfields_addon_activity';
+
     public const LONG_NAME = 'sumfields-addon-activity';
+
     public const CLASS_PREFIX = 'CRM_SumfieldsAddonActivity';
 
     /**
      * Translate a string using the extension's domain.
-     *
      * If the extension doesn't have a specific translation
      * for the string, fallback to the default translations.
      *
@@ -31,6 +32,7 @@ class CRM_SumfieldsAddonActivity_ExtensionUtil
         if (!array_key_exists('domain', $params)) {
             $params['domain'] = [self::LONG_NAME, null];
         }
+
         return ts($text, $params);
     }
 
@@ -50,6 +52,7 @@ class CRM_SumfieldsAddonActivity_ExtensionUtil
         if ($file === null) {
             return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
         }
+
         return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
     }
 
@@ -210,7 +213,6 @@ function _sumfields_addon_activity_civix_civicrm_disable()
  * @return mixed
  *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
  *   for 'enqueue', returns void
- *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _sumfields_addon_activity_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = null)
@@ -234,7 +236,6 @@ function _sumfields_addon_activity_civix_upgrader()
 
 /**
  * Search directory tree for files which match a glob pattern.
- *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
  * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
  * for backward compatibility of extension code that uses it.
@@ -251,7 +252,6 @@ function _sumfields_addon_activity_civix_find_files($dir, $pattern)
 
 /**
  * (Delegated) Implements hook_civicrm_managed().
- *
  * Find any *.mgd.php files, merge their content, and return.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
@@ -276,9 +276,7 @@ function _sumfields_addon_activity_civix_civicrm_managed(&$entities)
 
 /**
  * (Delegated) Implements hook_civicrm_caseTypes().
- *
  * Find any and return any files matching "xml/case/*.xml"
- *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
@@ -305,9 +303,7 @@ function _sumfields_addon_activity_civix_civicrm_caseTypes(&$caseTypes)
 
 /**
  * (Delegated) Implements hook_civicrm_angularModules().
- *
  * Find any and return any files matching "ang/*.ang.php"
- *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
@@ -331,7 +327,6 @@ function _sumfields_addon_activity_civix_civicrm_angularModules(&$angularModules
 
 /**
  * (Delegated) Implements hook_civicrm_themes().
- *
  * Find any and return any files matching "*.theme.php"
  */
 function _sumfields_addon_activity_civix_civicrm_themes(&$themes)
@@ -351,7 +346,6 @@ function _sumfields_addon_activity_civix_civicrm_themes(&$themes)
 
 /**
  * Glob wrapper which is guaranteed to return an array.
- *
  * The documentation for glob() says, "On some systems it is impossible to
  * distinguish between empty match and an error." Anecdotally, the return
  * result for an empty match is sometimes array() and sometimes FALSE.
@@ -366,6 +360,7 @@ function _sumfields_addon_activity_civix_civicrm_themes(&$themes)
 function _sumfields_addon_activity_civix_glob($pattern)
 {
     $result = glob($pattern);
+
     return is_array($result) ? $result : [];
 }
 
@@ -390,6 +385,7 @@ function _sumfields_addon_activity_civix_insert_navigation_menu(&$menu, $path, $
                 'active' => 1,
             ], $item),
         ];
+
         return true;
     } else {
         // Find an recurse into the next level down
@@ -404,6 +400,7 @@ function _sumfields_addon_activity_civix_insert_navigation_menu(&$menu, $path, $
                 $found = _sumfields_addon_activity_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
             }
         }
+
         return $found;
     }
 }
@@ -469,7 +466,6 @@ function _sumfields_addon_activity_civix_civicrm_alterSettingsFolders(&$metaData
 
 /**
  * (Delegated) Implements hook_civicrm_entityTypes().
- *
  * Find any *.entityType.php files, merge their content, and return.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes

--- a/sumfields_addon_activity.php
+++ b/sumfields_addon_activity.php
@@ -89,7 +89,6 @@ function sumfields_addon_activity_civicrm_upgrade($op, CRM_Queue_Queue $queue = 
 
 /**
  * Implements hook_civicrm_managed().
- *
  * Generate a list of entities to create/deactivate/delete when this module
  * is installed, disabled, uninstalled.
  *
@@ -102,7 +101,6 @@ function sumfields_addon_activity_civicrm_managed(&$entities)
 
 /**
  * Implements hook_civicrm_caseTypes().
- *
  * Add CiviCase types provided by this extension.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
@@ -114,7 +112,6 @@ function sumfields_addon_activity_civicrm_caseTypes(&$caseTypes)
 
 /**
  * Implements hook_civicrm_angularModules().
- *
  * Add Angular modules provided by this extension.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
@@ -137,7 +134,6 @@ function sumfields_addon_activity_civicrm_alterSettingsFolders(&$metaDataFolders
 
 /**
  * Implements hook_civicrm_entityTypes().
- *
  * Declare entity types provided by this module.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes

--- a/tests/phpunit/CRM/SumfieldsAddonActivity/DefinitionTest.php
+++ b/tests/phpunit/CRM/SumfieldsAddonActivity/DefinitionTest.php
@@ -21,7 +21,6 @@ class CRM_SumfieldsAddonActivity_DefinitionTest extends CRM_SumfieldsAddonActivi
      * Create contact
      *
      * @return int Contact ID
-     *
      * @throws \API_Exception
      * @throws \Civi\API\Exception\UnauthorizedException
      */
@@ -33,6 +32,7 @@ class CRM_SumfieldsAddonActivity_DefinitionTest extends CRM_SumfieldsAddonActivi
         self::assertCount(1, $result, 'Failed to create contact');
         $contact = $result->first();
         self::assertArrayHasKey('id', $contact, 'Contact ID not found');
+
         return (int)$contact['id'];
     }
 
@@ -43,7 +43,6 @@ class CRM_SumfieldsAddonActivity_DefinitionTest extends CRM_SumfieldsAddonActivi
      * @param string $customFieldLabel Custom field label
      *
      * @return mixed Raw field value
-     *
      * @throws \API_Exception
      * @throws \CiviCRM_API3_Exception
      * @throws \Civi\API\Exception\UnauthorizedException
@@ -65,6 +64,7 @@ class CRM_SumfieldsAddonActivity_DefinitionTest extends CRM_SumfieldsAddonActivi
             'custom_field_id' => $customFieldId,
         ]);
         self::assertCount(1, $result['values'], 'Failed to find custom field value');
+
         return (array_shift($result['values']))['raw'];
     }
 
@@ -104,6 +104,7 @@ class CRM_SumfieldsAddonActivity_DefinitionTest extends CRM_SumfieldsAddonActivi
         self::assertCount(1, $result, 'Failed to create activity');
         $activity = $result->first();
         self::assertArrayHasKey('id', $activity, 'activity ID not found');
+
         return (int)$activity['id'];
     }
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -20,6 +20,7 @@ $loader->register();
  *   The rest of the command to send.
  * @param string $decode
  *   Ex: 'json' or 'phpcode'.
+ *
  * @return string
  *   Response output (if the command executed normally).
  * @throws \RuntimeException
@@ -27,8 +28,8 @@ $loader->register();
  */
 function cv($cmd, $decode = 'json')
 {
-    $cmd = 'cv ' . $cmd;
-    $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+    $cmd = 'cv '.$cmd;
+    $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
     $oldOutput = getenv('CV_OUTPUT');
     putenv("CV_OUTPUT=json");
 
@@ -53,6 +54,7 @@ function cv($cmd, $decode = 'json')
             if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
                 throw new \RuntimeException("Command failed ($cmd):\n$result");
             }
+
             return $result;
 
         case 'json':


### PR DESCRIPTION
- Reformat PHP to PSR-12
- Reformat JS
- readme: use hyphens for `cv en some-extension`
- remove `,` after last element of inline arrays
