### PR TITLE
Standardize tests

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -22,8 +22,8 @@
         <url desc="Support">https://github.com/reflexive-communications/sumfields-addon-activity/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2023-03-09</releaseDate>
-    <version>1.2.0</version>
+    <releaseDate>2023-03-16</releaseDate>
+    <version>1.3.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.38</ver>

--- a/tests/phpunit/CRM/SumfieldsAddonActivity/ConfigTest.php
+++ b/tests/phpunit/CRM/SumfieldsAddonActivity/ConfigTest.php
@@ -1,11 +1,13 @@
 <?php
 
+use Civi\SumfieldsAddonActivity\HeadlessTestCase;
+
 /**
  * Testcases for the configuration.
  *
  * @group headless
  */
-class CRM_SumfieldsAddonActivity_ConfigTest extends CRM_SumfieldsAddonActivity_HeadlessBase
+class CRM_SumfieldsAddonActivity_ConfigTest extends HeadlessTestCase
 {
     /**
      * It checks that the defaultConfiguration function works well.

--- a/tests/phpunit/CRM/SumfieldsAddonActivity/ConfigTest.php
+++ b/tests/phpunit/CRM/SumfieldsAddonActivity/ConfigTest.php
@@ -3,8 +3,6 @@
 use Civi\SumfieldsAddonActivity\HeadlessTestCase;
 
 /**
- * Testcases for the configuration.
- *
  * @group headless
  */
 class CRM_SumfieldsAddonActivity_ConfigTest extends HeadlessTestCase

--- a/tests/phpunit/CRM/SumfieldsAddonActivity/DefinitionTest.php
+++ b/tests/phpunit/CRM/SumfieldsAddonActivity/DefinitionTest.php
@@ -1,17 +1,17 @@
 <?php
 
-use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
-
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
+use Civi\SumfieldsAddonActivity\HeadlessTestCase;
+use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
 
 /**
  * Testcases for the definitions.
  *
  * @group headless
  */
-class CRM_SumfieldsAddonActivity_DefinitionTest extends CRM_SumfieldsAddonActivity_HeadlessBase
+class CRM_SumfieldsAddonActivity_DefinitionTest extends HeadlessTestCase
 {
     public function setUpHeadless()
     {

--- a/tests/phpunit/CRM/SumfieldsAddonActivity/DefinitionTest.php
+++ b/tests/phpunit/CRM/SumfieldsAddonActivity/DefinitionTest.php
@@ -7,16 +7,10 @@ use Civi\SumfieldsAddonActivity\HeadlessTestCase;
 use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
 
 /**
- * Testcases for the definitions.
- *
  * @group headless
  */
 class CRM_SumfieldsAddonActivity_DefinitionTest extends HeadlessTestCase
 {
-    public function setUpHeadless()
-    {
-    }
-
     /**
      * Create contact
      *

--- a/tests/phpunit/CRM/SumfieldsAddonActivity/DefinitionTest.php
+++ b/tests/phpunit/CRM/SumfieldsAddonActivity/DefinitionTest.php
@@ -124,7 +124,7 @@ class CRM_SumfieldsAddonActivity_DefinitionTest extends HeadlessTestCase
             $activityDate = date('Y-m-d H:i', strtotime($before.' days ago'));
             $activityId = $this->addActivity($contactId, 1);
             // update activity with sql
-            $sql = "UPDATE civicrm_activity SET created_date = %1, activity_date_time = %1 WHERE id =  %2";
+            $sql = 'UPDATE civicrm_activity SET created_date = %1, activity_date_time = %1 WHERE id =  %2';
             $params = [
                 1 => [$activityDate, 'String'],
                 2 => [$activityId, 'Int'],
@@ -164,7 +164,7 @@ class CRM_SumfieldsAddonActivity_DefinitionTest extends HeadlessTestCase
         $activityDate = date('Y-m-d H:i', strtotime('5 days ago'));
         $activityId = $this->addActivity($contactId, 1);
         // update activity with sql
-        $sql = "UPDATE civicrm_activity SET created_date = %1, activity_date_time = %1 WHERE id =  %2";
+        $sql = 'UPDATE civicrm_activity SET created_date = %1, activity_date_time = %1 WHERE id =  %2';
         $params = [
             1 => [$activityDate, 'String'],
             2 => [$activityId, 'Int'],

--- a/tests/phpunit/CRM/SumfieldsAddonActivity/HeadlessBase.php
+++ b/tests/phpunit/CRM/SumfieldsAddonActivity/HeadlessBase.php
@@ -35,28 +35,4 @@ class CRM_SumfieldsAddonActivity_HeadlessBase extends \PHPUnit\Framework\TestCas
             ->install('net.ourpowerbase.sumfields')
             ->apply(true);
     }
-
-    /**
-     * Create a clean DB after running tests
-     *
-     * @throws CRM_Extension_Exception_ParseException
-     */
-    public static function tearDownAfterClass(): void
-    {
-        \Civi\Test::headless()
-            ->uninstallMe(__DIR__)
-            ->uninstall('rc-base')
-            ->uninstall('net.ourpowerbase.sumfields')
-            ->apply(true);
-    }
-
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
 }

--- a/tests/phpunit/CRM/SumfieldsAddonActivity/ServiceTest.php
+++ b/tests/phpunit/CRM/SumfieldsAddonActivity/ServiceTest.php
@@ -4,8 +4,6 @@ use Civi\SumfieldsAddonActivity\HeadlessTestCase;
 use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
 
 /**
- * Testcases for Service class.
- *
  * @group headless
  */
 class CRM_SumfieldsAddonActivity_ServiceTest extends HeadlessTestCase

--- a/tests/phpunit/CRM/SumfieldsAddonActivity/ServiceTest.php
+++ b/tests/phpunit/CRM/SumfieldsAddonActivity/ServiceTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\SumfieldsAddonActivity\HeadlessTestCase;
 use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
 
 /**
@@ -7,7 +8,7 @@ use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
  *
  * @group headless
  */
-class CRM_SumfieldsAddonActivity_ServiceTest extends CRM_SumfieldsAddonActivity_HeadlessBase
+class CRM_SumfieldsAddonActivity_ServiceTest extends HeadlessTestCase
 {
     /*
      * It tests the sumfieldsDefinition function.

--- a/tests/phpunit/CRM/SumfieldsAddonActivity/UpgraderTest.php
+++ b/tests/phpunit/CRM/SumfieldsAddonActivity/UpgraderTest.php
@@ -3,8 +3,6 @@
 use Civi\SumfieldsAddonActivity\HeadlessTestCase;
 
 /**
- * Installer application tests.
- *
  * @group headless
  */
 class CRM_SumfieldsAddonActivity_UpgraderTest extends HeadlessTestCase

--- a/tests/phpunit/CRM/SumfieldsAddonActivity/UpgraderTest.php
+++ b/tests/phpunit/CRM/SumfieldsAddonActivity/UpgraderTest.php
@@ -1,11 +1,13 @@
 <?php
 
+use Civi\SumfieldsAddonActivity\HeadlessTestCase;
+
 /**
  * Installer application tests.
  *
  * @group headless
  */
-class CRM_SumfieldsAddonActivity_UpgraderTest extends CRM_SumfieldsAddonActivity_HeadlessBase
+class CRM_SumfieldsAddonActivity_UpgraderTest extends HeadlessTestCase
 {
     /**
      * Test the install process.

--- a/tests/phpunit/Civi/SumfieldsAddonActivity/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/SumfieldsAddonActivity/HeadlessTestCase.php
@@ -4,14 +4,12 @@ namespace Civi\SumfieldsAddonActivity;
 
 use Civi\Test;
 use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
-use Civi\Test\TransactionalInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @group headless
  */
-class HeadlessTestCase extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
+class HeadlessTestCase extends TestCase implements HeadlessInterface
 {
     /**
      * Apply a forced rebuild of DB, thus

--- a/tests/phpunit/Civi/SumfieldsAddonActivity/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/SumfieldsAddonActivity/HeadlessTestCase.php
@@ -2,26 +2,19 @@
 
 namespace Civi\SumfieldsAddonActivity;
 
+use Civi\Test;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Testcases for Service class.
  *
  * @group headless
  */
-class HeadlessTestCase extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
+class HeadlessTestCase extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
 {
-    public function setUpHeadless()
-    {
-        return \Civi\Test::headless()
-            ->install('rc-base')
-            ->installMe(__DIR__)
-            ->install('net.ourpowerbase.sumfields')
-            ->apply();
-    }
-
     /**
      * Apply a forced rebuild of DB, thus
      * create a clean DB before running tests
@@ -30,11 +23,18 @@ class HeadlessTestCase extends \PHPUnit\Framework\TestCase implements HeadlessIn
      */
     public static function setUpBeforeClass(): void
     {
-        // Resets DB and install depended extension
-        \Civi\Test::headless()
+        // Resets DB
+        Test::headless()
             ->install('rc-base')
             ->installMe(__DIR__)
             ->install('net.ourpowerbase.sumfields')
             ->apply(true);
+    }
+
+    /**
+     * @return void
+     */
+    public function setUpHeadless(): void
+    {
     }
 }

--- a/tests/phpunit/Civi/SumfieldsAddonActivity/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/SumfieldsAddonActivity/HeadlessTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Civi\SumfieldsAddonActivity;
+
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
@@ -9,7 +11,7 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class CRM_SumfieldsAddonActivity_HeadlessBase extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
+class HeadlessTestCase extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
 {
     public function setUpHeadless()
     {

--- a/tests/phpunit/Civi/SumfieldsAddonActivity/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/SumfieldsAddonActivity/HeadlessTestCase.php
@@ -9,8 +9,6 @@ use Civi\Test\TransactionalInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Testcases for Service class.
- *
  * @group headless
  */
 class HeadlessTestCase extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,12 +1,14 @@
 <?php
 
+use Composer\Autoload\ClassLoader;
+
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable
 // Allow autoloading of PHPUnit helper classes in this extension.
-$loader = new \Composer\Autoload\ClassLoader();
+$loader = new ClassLoader();
 $loader->add('CRM_', __DIR__);
 $loader->add('Civi\\', __DIR__);
 $loader->add('api_', __DIR__);
@@ -29,9 +31,9 @@ $loader->register();
 function cv($cmd, $decode = 'json')
 {
     $cmd = 'cv '.$cmd;
-    $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
+    $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
     $oldOutput = getenv('CV_OUTPUT');
-    putenv("CV_OUTPUT=json");
+    putenv('CV_OUTPUT=json');
 
     // Execute `cv` in the original folder. This is a work-around for
     // phpunit/codeception, which seem to manipulate PWD.
@@ -51,8 +53,8 @@ function cv($cmd, $decode = 'json')
 
         case 'phpcode':
             // If the last output is /*PHPCODE*/, then we managed to complete execution.
-            if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
-                throw new \RuntimeException("Command failed ($cmd):\n$result");
+            if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
+                throw new RuntimeException("Command failed ($cmd):\n$result");
             }
 
             return $result;


### PR DESCRIPTION
- all test inherit single `HeadlessTestCase`
- remove `tearDown`
- rename `*HeadlessTest` to `*Test`
- move `HeadlessTestCase` to `\Civi` namespace
- standardize `setUpHeadless()` docblock
- test class docblock: keep only `@group headless`
- remove unused `HookInterface`, `TransactionalInterface`; if needed add only relevant test cases
