### PR TITLE
Move classes to \Civi namespace

### DIFF
--- a/CRM/SumfieldsAddonActivity/Upgrader.php
+++ b/CRM/SumfieldsAddonActivity/Upgrader.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\SumfieldsAddonActivity\Config;
 use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
 
 /**
@@ -14,7 +15,7 @@ class CRM_SumfieldsAddonActivity_Upgrader extends CRM_Extension_Upgrader_Base
      */
     public function install(): void
     {
-        $config = new CRM_SumfieldsAddonActivity_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         // Create default configs
         if (!$config->create()) {
             throw new CRM_Core_Exception(E::LONG_NAME.ts(' could not create configs in database'));
@@ -28,7 +29,7 @@ class CRM_SumfieldsAddonActivity_Upgrader extends CRM_Extension_Upgrader_Base
      */
     public function uninstall(): void
     {
-        $config = new CRM_SumfieldsAddonActivity_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         // delete current configs
         if (!$config->remove()) {
             throw new CRM_Core_Exception(E::LONG_NAME.ts(' could not remove configs from database'));
@@ -43,7 +44,7 @@ class CRM_SumfieldsAddonActivity_Upgrader extends CRM_Extension_Upgrader_Base
      */
     public function upgrade_5100(): bool
     {
-        $config = new CRM_SumfieldsAddonActivity_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $default = $config->defaultConfiguration();
         $config->load();
         $current = $config->get();

--- a/Civi/SumfieldsAddonActivity/Config.php
+++ b/Civi/SumfieldsAddonActivity/Config.php
@@ -1,6 +1,11 @@
 <?php
 
-class CRM_SumfieldsAddonActivity_Config extends CRM_RcBase_Config
+namespace Civi\SumfieldsAddonActivity;
+
+use CRM_Core_Exception;
+use CRM_RcBase_Config;
+
+class Config extends CRM_RcBase_Config
 {
     /**
      * Provides a default configuration object.

--- a/Civi/SumfieldsAddonActivity/Service.php
+++ b/Civi/SumfieldsAddonActivity/Service.php
@@ -1,8 +1,14 @@
 <?php
 
-use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
+namespace Civi\SumfieldsAddonActivity;
 
-class CRM_SumfieldsAddonActivity_Service
+use CRM_Activity_BAO_Activity;
+use CRM_Activity_BAO_ActivityContact;
+use CRM_Core_Smarty;
+use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
+use CRM_Utils_Array;
+
+class Service
 {
     public const MULTIPLE_OPTIONS = ['multiple' => true, 'class' => 'crm-select2 huge'];
 
@@ -30,7 +36,7 @@ class CRM_SumfieldsAddonActivity_Service
         if ($formName !== 'CRM_Sumfields_Form_SumFields') {
             return;
         }
-        $settings = new CRM_SumfieldsAddonActivity_Config(E::LONG_NAME);
+        $settings = new Config(E::LONG_NAME);
         $labels = [
             'activity-type' => E::ts('Activity Types'),
             'activity-type-desc' => E::ts('Activity types to be used when calculating activity summary fields.'),
@@ -88,7 +94,7 @@ class CRM_SumfieldsAddonActivity_Service
     {
         if ($formName == 'CRM_Sumfields_Form_SumFields') {
             // Save option fields as submitted.
-            $settings = new CRM_SumfieldsAddonActivity_Config(E::LONG_NAME);
+            $settings = new Config(E::LONG_NAME);
             $settings->updateSetting(
                 'activity_sumfields_activity_type_ids',
                 CRM_Utils_Array::value('activity_sumfields_activity_type_ids', $form->_submitValues)
@@ -127,7 +133,7 @@ class CRM_SumfieldsAddonActivity_Service
      */
     private static function rewriteSql($sql): string
     {
-        $settings = new CRM_SumfieldsAddonActivity_Config(E::LONG_NAME);
+        $settings = new Config(E::LONG_NAME);
         // Note: most of these token replacements fill in a sql IN statement,
         // e.g. field_name IN (%token). That means if the token is empty, we
         // get a SQL error. So... for each of these, if the token is empty,

--- a/info.xml
+++ b/info.xml
@@ -22,8 +22,8 @@
         <url desc="Support">https://github.com/reflexive-communications/sumfields-addon-activity/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2023-03-21</releaseDate>
-    <version>1.4.0</version>
+    <releaseDate>2023-04-07</releaseDate>
+    <version>2.0.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.43</ver>

--- a/sumfields_addon_activity.php
+++ b/sumfields_addon_activity.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\SumfieldsAddonActivity\Service;
+
 require_once 'sumfields_addon_activity.civix.php';
 
 /**
@@ -17,7 +19,7 @@ function sumfields_addon_activity_civicrm_config(&$config): void
  */
 function sumfields_addon_activity_civicrm_sumfields_definitions(&$custom): void
 {
-    CRM_SumfieldsAddonActivity_Service::sumfieldsDefinition($custom);
+    Service::sumfieldsDefinition($custom);
 }
 
 /**
@@ -27,7 +29,7 @@ function sumfields_addon_activity_civicrm_sumfields_definitions(&$custom): void
  */
 function sumfields_addon_activity_civicrm_buildForm($formName, &$form): void
 {
-    CRM_SumfieldsAddonActivity_Service::buildForm($formName, $form);
+    Service::buildForm($formName, $form);
 }
 
 /**
@@ -37,5 +39,5 @@ function sumfields_addon_activity_civicrm_buildForm($formName, &$form): void
  */
 function sumfields_addon_activity_civicrm_postProcess($formName, &$form): void
 {
-    CRM_SumfieldsAddonActivity_Service::postProcess($formName, $form);
+    Service::postProcess($formName, $form);
 }

--- a/tests/phpunit/CRM/SumfieldsAddonActivity/UpgraderTest.php
+++ b/tests/phpunit/CRM/SumfieldsAddonActivity/UpgraderTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Civi\SumfieldsAddonActivity\Config;
 use Civi\SumfieldsAddonActivity\HeadlessTestCase;
+use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
 
 /**
  * @group headless
@@ -36,7 +38,7 @@ class CRM_SumfieldsAddonActivity_UpgraderTest extends HeadlessTestCase
     {
         $installer = new CRM_SumfieldsAddonActivity_Upgrader();
         self::assertEmpty($installer->install());
-        $config = new CRM_SumfieldsAddonActivity_Config(CRM_SumfieldsAddonActivity_ExtensionUtil::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->load();
         $cfg = $config->get();
         $needsToBeRemoved = ['activity_sumfields_date_activity_type_ids', 'activity_sumfields_date_activity_status_ids', 'activity_sumfields_date_record_type_id'];

--- a/tests/phpunit/Civi/SumfieldsAddonActivity/ConfigTest.php
+++ b/tests/phpunit/Civi/SumfieldsAddonActivity/ConfigTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use Civi\SumfieldsAddonActivity\HeadlessTestCase;
+namespace Civi\SumfieldsAddonActivity;
 
 /**
  * @group headless
  */
-class CRM_SumfieldsAddonActivity_ConfigTest extends HeadlessTestCase
+class ConfigTest extends HeadlessTestCase
 {
     /**
      * @return void
@@ -20,7 +20,7 @@ class CRM_SumfieldsAddonActivity_ConfigTest extends HeadlessTestCase
             'activity_sumfields_date_activity_status_ids',
             'activity_sumfields_date_record_type_id',
         ];
-        $config = new CRM_SumfieldsAddonActivity_Config('config_test');
+        $config = new Config('config_test');
         $defaults = $config->defaultConfiguration();
         foreach ($expectedKeys as $k) {
             self::assertTrue(array_key_exists($k, $defaults));
@@ -43,7 +43,7 @@ class CRM_SumfieldsAddonActivity_ConfigTest extends HeadlessTestCase
             'activity_sumfields_date_activity_status_ids' => [2, 3, 5],
             'activity_sumfields_date_record_type_id' => [1],
         ];
-        $config = new CRM_SumfieldsAddonActivity_Config('config_test');
+        $config = new Config('config_test');
         self::assertTrue($config->create());
         foreach ($testData as $key => $value) {
             self::assertTrue($config->updateSetting($key, $value));
@@ -66,7 +66,7 @@ class CRM_SumfieldsAddonActivity_ConfigTest extends HeadlessTestCase
             'activity_sumfields_date_activity_status_ids' => [2, 3, 5],
             'activity_sumfields_date_record_type_id' => [1],
         ];
-        $config = new CRM_SumfieldsAddonActivity_Config('config_test');
+        $config = new Config('config_test');
         $config->update($testData);
         foreach ($testData as $key => $value) {
             self::assertSame($value, $config->getSetting($key));

--- a/tests/phpunit/Civi/SumfieldsAddonActivity/DefinitionTest.php
+++ b/tests/phpunit/Civi/SumfieldsAddonActivity/DefinitionTest.php
@@ -5,6 +5,7 @@ namespace Civi\SumfieldsAddonActivity;
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
+use Civi\RcBase\Utils\DB;
 use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
 
 /**
@@ -137,7 +138,7 @@ class DefinitionTest extends HeadlessTestCase
             $activityDate = date('Y-m-d H:i', strtotime($before.' days ago'));
             $activityId = $this->addActivity($contactId, 1);
             // update activity with sql
-            \Civi\RcBase\Utils\DB::query('UPDATE civicrm_activity SET created_date = %1, activity_date_time = %1 WHERE id =  %2', [
+            DB::query('UPDATE civicrm_activity SET created_date = %1, activity_date_time = %1 WHERE id =  %2', [
                 1 => [$activityDate, 'String'],
                 2 => [$activityId, 'Positive'],
             ]);
@@ -182,7 +183,7 @@ class DefinitionTest extends HeadlessTestCase
         $activityDate = date('Y-m-d H:i', strtotime('5 days ago'));
         $activityId = $this->addActivity($contactId, 1);
         // update activity with sql
-        \Civi\RcBase\Utils\DB::query('UPDATE civicrm_activity SET created_date = %1, activity_date_time = %1 WHERE id =  %2', [
+        DB::query('UPDATE civicrm_activity SET created_date = %1, activity_date_time = %1 WHERE id =  %2', [
             1 => [$activityDate, 'String'],
             2 => [$activityId, 'Positive'],
         ]);

--- a/tests/phpunit/Civi/SumfieldsAddonActivity/DefinitionTest.php
+++ b/tests/phpunit/Civi/SumfieldsAddonActivity/DefinitionTest.php
@@ -1,15 +1,16 @@
 <?php
 
+namespace Civi\SumfieldsAddonActivity;
+
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\CustomField;
-use Civi\SumfieldsAddonActivity\HeadlessTestCase;
 use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
 
 /**
  * @group headless
  */
-class CRM_SumfieldsAddonActivity_DefinitionTest extends HeadlessTestCase
+class DefinitionTest extends HeadlessTestCase
 {
     /**
      * Create contact
@@ -114,7 +115,7 @@ class CRM_SumfieldsAddonActivity_DefinitionTest extends HeadlessTestCase
      */
     public function hook_civicrm_sumfields_definitions(&$custom)
     {
-        CRM_SumfieldsAddonActivity_Service::sumfieldsDefinition($custom);
+        Service::sumfieldsDefinition($custom);
     }
 
     /**
@@ -126,7 +127,7 @@ class CRM_SumfieldsAddonActivity_DefinitionTest extends HeadlessTestCase
      */
     public function testNumberOfActivitiesInLastIntervals()
     {
-        $settings = new CRM_SumfieldsAddonActivity_Config(E::LONG_NAME);
+        $settings = new Config(E::LONG_NAME);
         self::assertTrue($settings->updateSetting('activity_sumfields_activity_type_ids', [1]));
         self::assertTrue($settings->updateSetting('activity_sumfields_record_type_id', [2]));
 
@@ -173,7 +174,7 @@ class CRM_SumfieldsAddonActivity_DefinitionTest extends HeadlessTestCase
      */
     public function testDateOfActivities()
     {
-        $settings = new CRM_SumfieldsAddonActivity_Config(E::LONG_NAME);
+        $settings = new Config(E::LONG_NAME);
         self::assertTrue($settings->updateSetting('activity_sumfields_date_activity_type_ids', [1]));
         self::assertTrue($settings->updateSetting('activity_sumfields_date_record_type_id', [2]));
 

--- a/tests/phpunit/Civi/SumfieldsAddonActivity/ServiceTest.php
+++ b/tests/phpunit/Civi/SumfieldsAddonActivity/ServiceTest.php
@@ -1,12 +1,14 @@
 <?php
 
-use Civi\SumfieldsAddonActivity\HeadlessTestCase;
+namespace Civi\SumfieldsAddonActivity;
+
+use CRM_Sumfields_Form_SumFields;
 use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
 
 /**
  * @group headless
  */
-class CRM_SumfieldsAddonActivity_ServiceTest extends HeadlessTestCase
+class ServiceTest extends HeadlessTestCase
 {
     /**
      * @return void
@@ -14,7 +16,7 @@ class CRM_SumfieldsAddonActivity_ServiceTest extends HeadlessTestCase
     public function testSumfieldsDefinition()
     {
         $definitions = [];
-        self::assertEmpty(CRM_SumfieldsAddonActivity_Service::sumfieldsDefinition($definitions));
+        self::assertEmpty(Service::sumfieldsDefinition($definitions));
         // the definition list has to be extended.
         self::assertTrue(array_key_exists('fields', $definitions));
         self::assertTrue(array_key_exists('optgroups', $definitions));
@@ -31,7 +33,7 @@ class CRM_SumfieldsAddonActivity_ServiceTest extends HeadlessTestCase
     public function testBuildFormDoesNothingWhenTheFormIsIrrelevant()
     {
         $form = new CRM_Sumfields_Form_SumFields();
-        self::assertEmpty(CRM_SumfieldsAddonActivity_Service::buildForm('irrelevant-form-name', $form));
+        self::assertEmpty(Service::buildForm('irrelevant-form-name', $form));
     }
 
     /**
@@ -42,8 +44,8 @@ class CRM_SumfieldsAddonActivity_ServiceTest extends HeadlessTestCase
     {
         $form = new CRM_Sumfields_Form_SumFields();
         $form->assign('fieldsets', []);
-        self::assertEmpty(CRM_SumfieldsAddonActivity_Service::buildForm(CRM_Sumfields_Form_SumFields::class, $form));
-        self::assertEmpty(CRM_SumfieldsAddonActivity_Service::buildForm('Not_Relevant_Class_Name', $form));
+        self::assertEmpty(Service::buildForm(CRM_Sumfields_Form_SumFields::class, $form));
+        self::assertEmpty(Service::buildForm('Not_Relevant_Class_Name', $form));
     }
 
     /**
@@ -53,7 +55,7 @@ class CRM_SumfieldsAddonActivity_ServiceTest extends HeadlessTestCase
     public function testPostProcessDoesNothingWhenTheFormIsIrrelevant()
     {
         $form = new CRM_Sumfields_Form_SumFields();
-        self::assertEmpty(CRM_SumfieldsAddonActivity_Service::postProcess('irrelevant-form-name', $form));
+        self::assertEmpty(Service::postProcess('irrelevant-form-name', $form));
     }
 
     /**
@@ -76,7 +78,7 @@ class CRM_SumfieldsAddonActivity_ServiceTest extends HeadlessTestCase
             'activity_sumfields_date_record_type_id' => $expectedContactRecortId,
         ];
         $form->setVar('_submitValues', $submit);
-        self::assertEmpty(CRM_SumfieldsAddonActivity_Service::postProcess(CRM_Sumfields_Form_SumFields::class, $form));
+        self::assertEmpty(Service::postProcess(CRM_Sumfields_Form_SumFields::class, $form));
     }
 
     /**
@@ -99,8 +101,8 @@ class CRM_SumfieldsAddonActivity_ServiceTest extends HeadlessTestCase
             'activity_sumfields_date_record_type_id' => $expectedContactRecortId,
         ];
         $form->setVar('_submitValues', $submit);
-        self::assertEmpty(CRM_SumfieldsAddonActivity_Service::postProcess(CRM_Sumfields_Form_SumFields::class, $form));
-        $config = new CRM_SumfieldsAddonActivity_Config(E::LONG_NAME);
+        self::assertEmpty(Service::postProcess(CRM_Sumfields_Form_SumFields::class, $form));
+        $config = new Config(E::LONG_NAME);
         self::assertSame($expectedActivityTypeIds, $config->getSetting('activity_sumfields_activity_type_ids'));
         self::assertSame($expectedActivityTypeIds, $config->getSetting('activity_sumfields_date_activity_type_ids'));
         self::assertSame($expectedActivityStatusIds, $config->getSetting('activity_sumfields_activity_status_ids'));

--- a/tests/phpunit/Civi/SumfieldsAddonActivity/ServiceTest.php
+++ b/tests/phpunit/Civi/SumfieldsAddonActivity/ServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace Civi\SumfieldsAddonActivity;
 
+use CRM_Activity_BAO_Activity;
+use CRM_Activity_BAO_ActivityContact;
 use CRM_Sumfields_Form_SumFields;
 use CRM_SumfieldsAddonActivity_ExtensionUtil as E;
 


### PR DESCRIPTION
- move classes to `\Civi\ExtensionName` namespace
- no manual changes
